### PR TITLE
:wrench: run compile-cv action on merge queue

### DIFF
--- a/.github/workflows/compile-cv.yml
+++ b/.github/workflows/compile-cv.yml
@@ -7,6 +7,7 @@ on:
   pull_request:  
     branches:
       - '**'  # Runs on all PRs
+  merge_group:  # Enable on merge queue
   workflow_dispatch:  # Allows manual triggering if needed
 
 permissions:


### PR DESCRIPTION
Allows the workflow to be used as a required Status Check on merge queues as per https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#status-checks-with-github-actions-and-a-merge-queue.